### PR TITLE
refactor: add CORS configuration if not kubernetes profile.

### DIFF
--- a/src/main/kotlin/com/jtm/blog/entrypoint/configuration/CorsConfiguration.kt
+++ b/src/main/kotlin/com/jtm/blog/entrypoint/configuration/CorsConfiguration.kt
@@ -1,12 +1,14 @@
 package com.jtm.blog.entrypoint.configuration
 
 import org.springframework.context.annotation.Configuration
+import org.springframework.context.annotation.Profile
 import org.springframework.web.reactive.config.CorsRegistry
 import org.springframework.web.reactive.config.EnableWebFlux
 import org.springframework.web.reactive.config.WebFluxConfigurer
 
 @EnableWebFlux
 @Configuration
+@Profile("!kubernetes")
 open class CorsConfiguration: WebFluxConfigurer {
 
     override fun addCorsMappings(registry: CorsRegistry) {


### PR DESCRIPTION
- The CORS configuration is needed for testing outside the kubernetes cluster.